### PR TITLE
:sparkles: Adds support for Hass.io 0.64 and the new 'build.json' file

### DIFF
--- a/example/build.json
+++ b/example/build.json
@@ -1,0 +1,12 @@
+{
+    "type": "addon",
+    "image": "hassioaddons/example-{arch}",    
+    "squashs": true,
+    "build_from": {
+        "aarch64": "hassioaddons/base-aarch64:latest",
+        "amd64": "hassioaddons/base-amd64:latest",
+        "armhf": "hassioaddons/base-armhf:latest",
+        "i386": "hassioaddons/base-i386:latest"
+    },
+    "args": {}
+}

--- a/example/config.json
+++ b/example/config.json
@@ -2,7 +2,6 @@
     "name": "Example",
     "slug": "example",
     "version": "0.0.1",
-    "type": "addon",
 
     "description": "Example add-on for Hass.io",
     "maintainer": "Franck Nijhof <frenck@addon.community>",
@@ -17,14 +16,10 @@
         "armhf",
         "i386"
     ],
-    "from": "hassioaddons/base-{arch}",
-    "squashs": true,
     
     "startup": "application",
     "boot": "auto",
 
     "options": {},
-    "schema": {},
-
-    "image": "hassioaddons/example-{arch}"
+    "schema": {}
   }


### PR DESCRIPTION
# Proposed Changes

Adds support for Hass.io 0.64

## Related Issues

None