### PR TITLE
Replace Hass.io with Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@
 
 [![Support Frenck on Patreon][patreon-shield]][patreon]
 
-Example add-on by Community Hass.io add-ons.
+Example add-on by Community Home Assistant add-ons.
 
 ## About
 
-This is an example add-on for Hass.io. When started, it displays a
+This is an example add-on for Home Assistant. When started, it displays a
 random quote every 5 seconds.
 
 It shows off several features and structures like:
@@ -35,8 +35,8 @@ It shows off several features and structures like:
 - The use of the `config.json` and `build.json` files.
 - General shell scripting structure (`run.sh`).
 - Quality assurance using CodeClimate.
-- Continuous integration and deployment using CircleCI.
-- Usage of the Community Hass.io Add-ons build environment.
+- Continuous integration and deployment using GitLab.
+- Usage of the Community Home Assistant Add-ons build environment.
 - Small use of the Bash function library in our base images.
 - The use of Docker label schema.
 

--- a/example/.README.j2
+++ b/example/.README.j2
@@ -8,11 +8,11 @@
 
 [![Support Frenck on Patreon][patreon-shield]][patreon]
 
-Example add-on by Community Hass.io add-ons.
+Example add-on by Community Home Assistant add-ons.
 
 ## About
 
-This is an example add-on for Hass.io. When started, it displays a
+This is an example add-on for Home Assistant. When started, it displays a
 random quote every 5 seconds.
 
 It shows off several features and structures like:
@@ -22,8 +22,8 @@ It shows off several features and structures like:
 - The use of the `config.json` and `build.json` files.
 - General shell scripting structure (`run.sh`).
 - Quality assurance using CodeClimate.
-- Continuous integration and deployment using CircleCI.
-- Usage of the Community Hass.io Add-ons build environment.
+- Continuous integration and deployment using GitLab.
+- Usage of the Community Home Assistant Add-ons build environment.
 - Small use of the Bash function library in our base images.
 - The use of Docker label schema.
 

--- a/example/DOCS.md
+++ b/example/DOCS.md
@@ -1,6 +1,6 @@
 # Home Assistant Community Add-on: Example
 
-This is an example add-on for Hass.io. When started, it displays a
+This is an example add-on for Home Assistant. When started, it displays a
 random quote every 5 seconds.
 
 It shows off several features and structures like:
@@ -10,8 +10,8 @@ It shows off several features and structures like:
 - The use of the `config.json` and `build.json` files.
 - General shell scripting structure (`run.sh`).
 - Quality assurance using CodeClimate.
-- Continuous integration and deployment using CircleCI.
-- Usage of the Community Hass.io Add-ons build environment.
+- Continuous integration and deployment using GitLab.
+- Usage of the Community Home Assistant Add-ons build environment.
 - Small use of the Bash function library in our base images.
 - The use of Docker label schema.
 
@@ -40,7 +40,7 @@ seconds_between_quotes: 5
 
 ### Option: `log_level`
 
-The `log_level` option controls the level of log output by the addon and can
+The `log_level` option controls the level of log output by the add-on and can
 be changed to be more or less verbose, which might be useful when you are
 dealing with an unknown issue. Possible values are:
 

--- a/example/config.json
+++ b/example/config.json
@@ -2,7 +2,7 @@
   "name": "Example",
   "version": "dev",
   "slug": "example",
-  "description": "Example add-on by Community Hass.io Add-ons",
+  "description": "Example add-on by Community Home Assistant Add-ons",
   "url": "https://github.com/hassio-addons/addon-example",
   "startup": "application",
   "init": false,

--- a/example/rootfs/usr/bin/example1.sh
+++ b/example/rootfs/usr/bin/example1.sh
@@ -2,7 +2,7 @@
 # ==============================================================================
 # Home Assistant Community Add-on: Example
 #
-# Example add-on for Hass.io.
+# Example add-on for Home Assistant.
 # This add-on displays a random quote every X seconds.
 # ==============================================================================
 

--- a/example/rootfs/usr/bin/example2.sh
+++ b/example/rootfs/usr/bin/example2.sh
@@ -2,7 +2,7 @@
 # ==============================================================================
 # Home Assistant Community Add-on: Example
 #
-# Example add-on for Hass.io.
+# Example add-on for Home Assistant.
 # ------------------------------------------------------------------------------
 main() {
     bashio::log.trace "${FUNCNAME[0]}"


### PR DESCRIPTION
# Proposed Changes

Replace Hass.io with Home Assistant to match the upstream naming.

Not sure if it makes sense to update:  `- Usage of the Community Hass.io Add-ons build environment.`. The repo was archived and it looks like that GitLab is the most recent option to build the add-on in a simple way.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/