### PR TITLE
Upgrade add-on base image to 9.0.0

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=hassioaddons/base:8.0.3
+ARG BUILD_FROM=ghcr.io/hassio-addons/base/amd64:9.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
@@ -7,8 +7,8 @@ COPY rootfs /
 
 # Setup base
 RUN apk add --no-cache \
-    coreutils=8.32-r0 \
-    wget=1.20.3-r1
+    coreutils=8.32-r2 \
+    wget=1.21.1-r1
 
 # Build arguments
 ARG BUILD_ARCH

--- a/example/build.json
+++ b/example/build.json
@@ -1,9 +1,9 @@
 {
   "build_from": {
-    "aarch64": "hassioaddons/base-aarch64:8.0.3",
-    "amd64": "hassioaddons/base-amd64:8.0.3",
-    "armhf": "hassioaddons/base-armhf:8.0.3",
-    "armv7": "hassioaddons/base-armv7:8.0.3",
-    "i386": "hassioaddons/base-i386:8.0.3"
+    "aarch64": "ghcr.io/hassio-addons/base/aarch64:9.0.0",
+    "amd64": "ghcr.io/hassio-addons/base/amd64:9.0.0",
+    "armhf": "ghcr.io/hassio-addons/base/armhf:9.0.0",
+    "armv7": "ghcr.io/hassio-addons/base/armv7:9.0.0",
+    "i386": "ghcr.io/hassio-addons/base/i386:9.0.0"
   }
 }

--- a/example/config.json
+++ b/example/config.json
@@ -6,7 +6,6 @@
   "url": "https://github.com/hassio-addons/addon-example",
   "init": false,
   "arch": ["aarch64", "amd64", "armhf", "armv7", "i386"],
-  "hassio_api": true,
   "options": {
     "log_level": "info",
     "seconds_between_quotes": 5


### PR DESCRIPTION
# Proposed Changes

Upgrades add-on base image to 9.0.0, providing Alpine 3.13.
Removes the now no longer needed Supervisor API setting.
