### PR TITLE
Dispatch correct version number to updater

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -178,7 +178,7 @@ jobs:
               "addon": "${{ needs.information.outputs.slug }}",
               "name": "${{ needs.information.outputs.name }}",
               "repository": "${{ github.repository }}",
-              "version": "${{ needs.information.outputs.version }}"
+              "version": "${{ github.event.release.tag_name }}"
             }
 
   publish-stable:
@@ -202,5 +202,5 @@ jobs:
               "addon": "${{ needs.information.outputs.slug }}",
               "name": "${{ needs.information.outputs.name }}",
               "repository": "${{ github.repository }}",
-              "version": "${{ needs.information.outputs.version }}"
+              "version": "${{ github.event.release.tag_name }}"
             }


### PR DESCRIPTION
# Proposed Changes

This PR address the issue that a possible incomplete version tag is dispatched to the updater.
In the case of a beta or stable channel, a GitHub tag would be present, which should be passed down.

It is needed in order to generate correct GitHub releases URLs
