### PR TITLE
Add rootfs to addon

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -2,6 +2,9 @@ ARG BUILD_FROM=ghcr.io/hassio-addons/base:12.2.1
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
+# Copy root filesystem
+COPY rootfs /
+
 # Setup base
 RUN apk add --no-cache \
     coreutils=9.1-r0 \


### PR DESCRIPTION
# Proposed Changes

#121 removed two lines which copied the rootfs earlier. This pull requests adds them back in.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
