### PR TITLE
🐛 Fix quote fetching under Bashio inherit_errexit

### DIFF
--- a/example/rootfs/usr/bin/example1.sh
+++ b/example/rootfs/usr/bin/example1.sh
@@ -25,6 +25,9 @@ get_quote_online() {
     number=$(( ( RANDOM % 999 )  + 1 ))
     html=$(wget -q -O - "https://www.quotationspage.com/quote/${number}.html")
 
+    # The page might not contain a quote at all, in which case grep exits
+    # non-zero. Bashio runs with errexit (and inherit_errexit), so swallow
+    # that here and let the caller deal with an empty quote instead.
     quote=$(grep -e "<dt>" -e "</dd>" <<< "${html}" \
         | awk -F'[<>]' '{
             if($2 ~ /dt/)
@@ -32,7 +35,7 @@ get_quote_online() {
             else if($4 ~ /b/)
                 { print "-- " $7 "\\n(" $19 ")"}
         }'
-    )
+    ) || true
 
     echo "${quote}"
 }
@@ -81,11 +84,15 @@ display_quote() {
 
     bashio::log.trace "${FUNCNAME[0]}"
 
+    quote=""
     if wget -q --spider https://www.quotationspage.com; then
         quote=$(get_quote_online)
-    else
+    fi
+
+    if bashio::var.is_empty "${quote}"; then
         bashio::log.notice \
-            'Could not connect to quotationspage.com, using an offline quote'
+            'Could not fetch a quote from quotationspage.com,' \
+            'using an offline quote'
         quote=$(get_quote_offline)
     fi
 


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The base image was bumped to v21.0.2, which ships Bashio v0.19.0 (up from v0.17.5). Bashio v0.18.0 added `shopt -s inherit_errexit` to `lib/bashio.sh`, and that turns out to break `example1.sh`.

`get_quote_online` runs `quote=$(grep ... | awk ...)`. When the fetched page contains no quote markup, grep exits non-zero and `pipefail` propagates it. Previously the command substitution in `quote=$(get_quote_online)` had errexit disabled inside the subshell, so the function carried on and returned an empty string. With `inherit_errexit` that subshell now inherits errexit, aborts on the grep failure, and takes the whole service down.

Reproduced side by side against the real library at both tags with the same unparsable page: v0.17.5 exits 0, v0.19.0 exits 1.

This PR:

* Swallows the grep failure explicitly (with a comment explaining the errexit interaction), so an unparsable page yields an empty quote instead of killing the script.
* Makes `display_quote` treat an empty online quote the same as being offline, falling back to the built-in quote set rather than printing nothing.

Verified: the no-match page now falls back cleanly and exits 0, the offline path is unchanged, and a page that does parse produces byte-identical output to the v0.17.5 baseline. Shellcheck passes.

The rest of the Bashio upgrade needs no changes here. `bashio::log.*` and `bashio::config` are unchanged, and the `addon` to `app` namespace rename does not touch this repo (none of those functions are used, and the old names keep deprecated aliases regardless).

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quote retrieval when no online result is available.
  * Added a reliable offline fallback when online fetching fails or returns an empty result.
  * Added logging to clarify when and why the fallback quote is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->